### PR TITLE
Add metrics exporters

### DIFF
--- a/application-metrics-exporter/elasticsearch-exporter.yaml
+++ b/application-metrics-exporter/elasticsearch-exporter.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: elasticsearch-exporter
+  name: elasticsearch-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elasticsearch-exporter
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: elasticsearch-exporter
+    spec:
+      containers:
+      - command:
+        - /bin/elasticsearch_exporter
+        - -es.uri=<ELASTICSEARCH_URL> #http://ES_STS_NAME.NAMESPACE.svc.cluster.local:PORT
+        - -es.all=true
+        image: justwatch/elasticsearch_exporter:1.0.2
+        imagePullPolicy: IfNotPresent
+        name: elasticsearch-exporter
+        ports:
+        - containerPort: 9108
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 25m
+            memory: 64Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000

--- a/application-metrics-exporter/mysql-exporter.yaml
+++ b/application-metrics-exporter/mysql-exporter.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mysql-exporter
+  labels:
+    app: mysql-exporter
+    pvc: percona-cstor-claim
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      app: mysql-exporter
+  template: 
+    metadata:
+      labels: 
+        app: mysql-exporter
+        pvc: percona-cstor-claim
+    spec:
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: mysql-exporter
+          image: prom/mysqld-exporter
+          env:
+            - name: DATA_SOURCE_NAME
+              value: "<MYSQL_URL>" #"READ_ONLY_USERNAME:READ_ONLY_PASSWORD@(MYSQL_DEPLOY_NAME.NAMESPACE.svc.cluster.local:PORT)/"
+          ports:
+            - containerPort: 9104
+              name: percona
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-exporter-service
+  labels:
+    app: mysql-exporter-service
+spec:
+  ports:
+    - name: exporter
+      port: 9104
+      protocol: TCP
+      targetPort: 9104
+  selector:
+      app: mysql-exporter
+

--- a/application-metrics-exporter/permission
+++ b/application-metrics-exporter/permission
@@ -1,0 +1,12 @@
+1. Create a read-only user in mysql:
+CREATE USER 'read-only' IDENTIFIED BY 'password';
+
+2. Grant permission to the user:
+GRANT SELECT ON *.* TO 'read-only';
+
+or if you want to grant only single database:
+GRANT SELECT ON DATABASE.* TO 'read-only';
+
+
+
+SELECT User FROM mysql.user;

--- a/application-metrics-exporter/postgresql-exporter.yaml
+++ b/application-metrics-exporter/postgresql-exporter.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: postgresql-exporter
+  labels:
+    app: postgresql-exporter
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      app: postgresql-exporter
+  template: 
+    metadata:
+      labels: 
+        app: postgresql-exporter
+    spec:
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: postgresql-exporter
+          image: wrouesnel/postgres_exporter
+          env:
+            - name: DATA_SOURCE_NAME
+              value: <POSTGRESQL_URL> #postgresql://USER:PASSWORD@POSTGRESQL.NAMESPACE.svc.cluster.local:PORT/DATABASE_NAME?sslmode=disable
+          ports:
+            - containerPort: 9187
+              name: postgresql
+

--- a/application-metrics-exporter/redis-exporter.yaml
+++ b/application-metrics-exporter/redis-exporter.yaml
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9121"
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis-exporter
+        image: oliver006/redis_exporter:latest
+        env:
+        - name: REDIS_ADDR
+          value: <REDIS_URL> #REDIS.NAMESPACE.svc.cluster.local:PORT
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 9121


### PR DESCRIPTION
Add metrics-exporters for following applications:
- Redis
- Elasticsearch
- PostgreSQL
- MySQL

Signed-off-by: Shivesh Abhishek <shivesh.abhishek@mayadata.io>